### PR TITLE
add MS + textual constraint #72

### DIFF
--- a/ImplementationGuide/markdown/Datenobjekte/ISiKTerminAppointment.md
+++ b/ImplementationGuide/markdown/Datenobjekte/ISiKTerminAppointment.md
@@ -90,9 +90,7 @@ Alle Statuswerte MÜSSEN durch ein bestätigungsrelevantes System unterstüzt we
 
 **Bedeutung:** Kodierung der Fachrichtung des Termins
 
-**Hinweis:** Falls eine Kodierung der Fachrichtung für den Termin angegeben werden kann, dann MUSS sie angegeben werden und exponiert werden können (eine Ausnahme bildet hier die fachrichtungs-unabhängige Terminplanung durch krankenhausinterne, zentrale Organisationseinheiten). 
-Die Kodierung der Fachrichtung des Termins SOLLTE der Kodierung des specialty des Schedules entsprechen, der innerhalb des Termins gebucht wird.
-
+**Hinweis:** Sofern aus den auf der Appointment-Ressource aufsetzenden Anwendungsfällen eine weitere Verarbeitung der Ressource durch einen menschlichen Nutzer nicht ausgeschlossen werden kann, MUSS das bestätigungsrelevante System mit dem Termin verbundenen Ressourcen (insb. `Appointment.slot`, `Appointment.slot.schedule`, `Appointment.participant:AkteurMedizinischeBehandlungseinheit.actor`) oder aus dem spezifischen Kontext verfügbare Informationen auswerten und das Element `Appointment.specialty` mit einem sinnvollen Wert kodieren (eine Ausnahme bildet hier zum Beispiel die fachrichtungs-unabhängige Terminplanung durch krankenhausinterne, zentrale Organisationseinheiten).
 Insbesondere ist die Kodierung der Fachrichtung des Termins notwendig im Kontext der Bereitstellung einer graphischen Oberfläche, wie sie Endnutzenden in einem Zuweiserportal/Patientenportal zur Ansicht gebracht wird.
  
 

--- a/ImplementationGuide/markdown/Datenobjekte/ISiKTerminAppointment.md
+++ b/ImplementationGuide/markdown/Datenobjekte/ISiKTerminAppointment.md
@@ -86,6 +86,16 @@ Alle Statuswerte MÜSSEN durch ein bestätigungsrelevantes System unterstüzt we
 
 **Hinweis:** Dies SOLL der Kodierung des serviceType eines Schedules entsprechen, der innerhalb des Termins gebucht wird.
 
+### `Appointment.specialty`
+
+**Bedeutung:** Kodierung der Fachrichtung des Termins
+
+**Hinweis:** Falls eine Kodierung der Fachrichtung für den Termin angegeben werden kann, dann MUSS sie angegeben werden und exponiert werden können (eine Ausnahme bildet hier die fachrichtungs-unabhängige Terminplanung durch krankenhausinterne, zentrale Organisationseinheiten). 
+Die Kodierung der Fachrichtung des Termins SOLLTE der Kodierung des specialty des Schedules entsprechen, der innerhalb des Termins gebucht wird.
+
+Insbesondere ist die Kodierung der Fachrichtung des Termins notwendig im Kontext der Bereitstellung einer graphischen Oberfläche, wie sie Endnutzenden in einem Zuweiserportal/Patientenportal zur Ansicht gebracht wird.
+ 
+
 ### `Appointment.priority.extension:Priority`
 
 **Bedeutung:** Kodierte Angabe der Priorität des Termins

--- a/Resources/input/fsh/ISiKTermin.fsh
+++ b/Resources/input/fsh/ISiKTermin.fsh
@@ -39,11 +39,11 @@ Id: ISiKTermin
 * participant[AkteurMedizinischeBehandlungseinheit].actor only Reference(HealthcareService)
 * participant[AkteurMedizinischeBehandlungseinheit].actor MS
 * participant[AkteurMedizinischeBehandlungseinheit].actor.reference 1..1 MS
-* specialty 0..* 
+* specialty 0..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
-* specialty contains Fachrichtung 0..1 
+* specialty contains Fachrichtung 0..1 MS
 * specialty[Fachrichtung] from $authorSpecialtyVS (required)
 * serviceType 1..* MS 
 * priority MS


### PR DESCRIPTION
Dieser Pull Request soll eine Lösung zur Änderung der Appointment.specialty mit gelockerter Kardinalität bereitstellen, die dennoch durch textuelle Festlegung ein Verarbeiten/Rendering in geforderten Szenarien (Terminbuchung über Patientenportal) sicherstellt - wie in AG-Sitzung am 5.5. beschlossen.