### PR TITLE
Add de.ihe-d.terminology dependency

### DIFF
--- a/Resources/sushi-config.yaml
+++ b/Resources/sushi-config.yaml
@@ -6,4 +6,5 @@ status: active
 version: 4.0.0-rc
 dependencies:
   de.gematik.isik-basismodul: 4.0.0-rc
+  de.ihe-d.terminology: 3.0.0
   hl7.fhir.extensions.r5: 4.0.1

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "4.0.1"
     ],
     "dependencies": {
-        "de.gematik.isik-basismodul": "4.0.0-rc"
+        "de.gematik.isik-basismodul": "4.0.0-rc",
+        "de.ihe-d.terminology": "3.0.0"
       }
 }


### PR DESCRIPTION
de.ihe-d.terminology enthält in der Version 3.0.0 expandierbare ValueSets inkl. CodeSystem-Definitionen.