### PR TITLE
update requirements regarding SLot search with Schedlue and Start defined -  ANFISK.302

### DIFF
--- a/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
+++ b/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
@@ -68,7 +68,7 @@ Für die Ressource Slot MUSS die REST-Interaktion "READ" implementiert werden.
 
     Anwendungshinweise: Weitere Informationen zur Suche nach "_id" finden sich in der [FHIR-Basisspezifikation - Abschnitt "Parameters for all resources"]https://hl7.org/fhir/R4/search.html#all).
 
-2. Der Suchparameter "schedule" MUSS in Kombination mit einem definierten Startzeitpunkt mittels Suchparameter "start"   unterstützt werden. Der Suchparameter "schedule" KANN alleinstehend unterstützt werden.
+2. Der Suchparameter "schedule" MUSS in Kombination mit einem definierten Startzeitpunkt mittels Suchparameter "start" unterstützt werden. Der Suchparameter "schedule" KANN alleinstehend unterstützt werden.
 Beim Fehlen des start-Suchparameters SOLL der aktuelle Zeitpunkt des Servers als Startzeitpunkt per Default verwendet werden (Slots aus der Vergangenheit wären somit nur dann zu liefern, wenn ein Client Slot.start explizit auf ein Datum aus der Vergangenheit setzt).
 
     Beispiele:

--- a/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
+++ b/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
@@ -69,7 +69,7 @@ Für die Ressource Slot MUSS die REST-Interaktion "READ" implementiert werden.
     Anwendungshinweise: Weitere Informationen zur Suche nach "_id" finden sich in der [FHIR-Basisspezifikation - Abschnitt "Parameters for all resources"]https://hl7.org/fhir/R4/search.html#all).
 
 2. Der Suchparameter "schedule" MUSS in Kombination mit einem definierten Startzeitpunkt mittels Suchparameter "start" unterstützt werden. Der Suchparameter "schedule" KANN alleinstehend unterstützt werden.
-Beim Fehlen des start-Suchparameters SOLL der aktuelle Zeitpunkt des Servers als Startzeitpunkt per Default verwendet werden (Slots aus der Vergangenheit wären somit nur dann zu liefern, wenn ein Client Slot.start explizit auf ein Datum aus der Vergangenheit setzt).
+Beim Fehlen des "start"-Suchparameters SOLL der aktuelle Zeitpunkt des Servers als Startzeitpunkt per Default verwendet werden.
 
     Beispiele:
 

--- a/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
+++ b/ImplementationGuide/markdown/Datenobjekte/ISiKTerminblockSlot.md
@@ -68,13 +68,18 @@ Für die Ressource Slot MUSS die REST-Interaktion "READ" implementiert werden.
 
     Anwendungshinweise: Weitere Informationen zur Suche nach "_id" finden sich in der [FHIR-Basisspezifikation - Abschnitt "Parameters for all resources"]https://hl7.org/fhir/R4/search.html#all).
 
-2. Der Suchparameter "schedule" MUSS unterstützt werden:
+2. Der Suchparameter "schedule" MUSS in Kombination mit einem definierten Startzeitpunkt mittels Suchparameter "start"   unterstützt werden. Der Suchparameter "schedule" KANN alleinstehend unterstützt werden.
+Beim Fehlen des start-Suchparameters SOLL der aktuelle Zeitpunkt des Servers als Startzeitpunkt per Default verwendet werden (Slots aus der Vergangenheit wären somit nur dann zu liefern, wenn ein Client Slot.start explizit auf ein Datum aus der Vergangenheit setzt).
 
     Beispiele:
+
+    ```GET [base]/Slot?schedule=Schedule/ISiKKalenderExample:start=2022-12-10T09:00:00Z```
 
     ```GET [base]/Slot?schedule=Schedule/ISiKKalenderExample```
 
     Anwendungshinweise: Weitere Informationen zur Suche nach "Slot.schedule" finden sich in der [FHIR-Basisspezifikation - Abschnitt "reference"]https://hl7.org/fhir/R4/search.html#reference).
+    
+    In diesem Fall ist auch ein Chaining auf weitere verknüpfte Akteure möglich: `GET https://example.org/fhir/Slot?schedule.actor:HealthcareService.type=https://example.org/fhir/CodeSystem/Behandlungsleistung|CT`
 
 3. Der Suchparameter "status" MUSS unterstützt werden:
 
@@ -84,19 +89,14 @@ Für die Ressource Slot MUSS die REST-Interaktion "READ" implementiert werden.
 
     Anwendungshinweise: Weitere Informationen zur Suche nach "Slot.status" finden sich in der [FHIR-Basisspezifikation - Abschnitt "Token Search"]https://hl7.org/fhir/R4/search.html#token).
 
-4. Der Suchparameter "start" MUSS unterstützt werden:
+4. Der Suchparameter "start" MUSS alleinstehend unterstützt werden:
 
     Beispiele:
 
     ```GET [base]/Slot?start=2022-12-10T09:00:00Z```
 
     Anwendungshinweise: Weitere Informationen zur Suche nach "Slot.start" finden sich in der [FHIR-Basisspezifikation - Abschnitt "Date Search"]https://hl7.org/fhir/R4/search.html#date).
-
-5. Abfrage aller verfügbaren Slots für einen Kalender: 
-
-    ```GET https://example.org/fhir/Slot?schedule=<Scheudule/ISiKKalenderExampple>```
-
-    Anwendungshinweise: In diesem Fall ist auch ein Chaining auf weitere verknüpfte Akteure möglich: `GET https://example.org/fhir/Slot?schedule.actor:HealthcareService.type=https://example.org/fhir/CodeSystem/Behandlungsleistung|CT`
+    
 ---
 
 ### Beispiele

--- a/ImplementationGuide/markdown/ReleaseNotes.md
+++ b/ImplementationGuide/markdown/ReleaseNotes.md
@@ -6,9 +6,10 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 
 Version 2.0.5
 
-Datum t.b.d
+Datum: 20.06.2024
 
 * Ändern der ValueSets von IHE https://github.com/gematik/spec-ISiK-Terminplanung/pull/186
+* Änderung der Anforderung für Suchanfrage zu Terminblöcken aus Kalendern https://github.com/gematik/spec-ISiK-Terminplanung/pull/190
 
 
 Version: 2.0.4


### PR DESCRIPTION
# Contributor Pull Request
<!--- Provide a general summary of your changes in the Title above -->

## Description
Anpassung der Anforderung auf Suchparameter, Sodass SLOT-Rückgaben mit dem Suchziel Schedule allein in KOMBINATION mit einem definierten Startdatum erfolgen MÜSSEN.

## Motivation and Context
Die Änderung soll verhindern, dass Slots aus der Vergangenheit beliebig expandiert werden.

## How has this been tested?
- review needed

## Snippets or Screenshots (if necessary):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Requirement update (breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Zu Prüfen
- [x] Vorgabe für Slots in der Zukunft nötig?
- [x] Suchparameter "start" alleinstehend MUSS?
- [x] Weitere Stellen tangiert (z.B. Operations?)