### PR TITLE
Allow multiple codings for “Fachrichtung” and “ErweiterterFachabteilungsschluessel” slices on .specialty

### DIFF
--- a/Resources/fsh-generated/resources/Appointment-ISiKTerminExampleExtendedICU.json
+++ b/Resources/fsh-generated/resources/Appointment-ISiKTerminExampleExtendedICU.json
@@ -44,11 +44,7 @@
         {
           "code": "INTM",
           "system": "http://ihe-d.de/CodeSystems/AerztlicheFachrichtungen"
-        }
-      ]
-    },
-    {
-      "coding": [
+        },
         {
           "code": "3600",
           "system": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel-erweitert"

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -84,6 +84,7 @@
       {
         "id": "Schedule.specialty",
         "path": "Schedule.specialty",
+        "comment": "Ein Kalendar kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplannung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
         "min": 1,
         "mustSupport": true
       },
@@ -139,6 +140,7 @@
           ],
           "rules": "open"
         },
+        "comment": "Ein dezidierter Kalender ist für jeden Akteur zu pflegen.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -84,7 +84,7 @@
       {
         "id": "Schedule.specialty",
         "path": "Schedule.specialty",
-        "comment": "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
+        "comment": "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality/Qualification des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -84,7 +84,7 @@
       {
         "id": "Schedule.specialty",
         "path": "Schedule.specialty",
-        "comment": "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality/Qualification des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
+        "comment": "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -84,7 +84,7 @@
       {
         "id": "Schedule.specialty",
         "path": "Schedule.specialty",
-        "comment": "Ein Kalendar kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplannung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
+        "comment": "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -84,6 +84,12 @@
       {
         "id": "Schedule.specialty",
         "path": "Schedule.specialty",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Schedule.specialty.coding",
+        "path": "Schedule.specialty.coding",
         "slicing": {
           "discriminator": [
             {
@@ -97,8 +103,8 @@
         "mustSupport": true
       },
       {
-        "id": "Schedule.specialty:Fachrichtung",
-        "path": "Schedule.specialty",
+        "id": "Schedule.specialty.coding:Fachrichtung",
+        "path": "Schedule.specialty.coding",
         "sliceName": "Fachrichtung",
         "comment": "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024).",
         "min": 1,
@@ -110,15 +116,15 @@
         }
       },
       {
-        "id": "Schedule.specialty:ErweiterterFachabteilungsschluessel",
-        "path": "Schedule.specialty",
+        "id": "Schedule.specialty.coding:ErweiterterFachabteilungsschluessel",
+        "path": "Schedule.specialty.coding",
         "sliceName": "ErweiterterFachabteilungsschluessel",
         "comment": "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern.",
         "min": 0,
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel-erweitert"
+          "valueSet": "http://fhir.de/ValueSet/dkgev/Fachabteilungsschluessel-erweitert"
         }
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
@@ -31,7 +31,7 @@
       {
         "id": "HealthcareService.specialty",
         "path": "HealthcareService.specialty",
-        "comment": "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt.",
+        "comment": "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt. Eine Behandlungseinheit kann multiprofessionell sein und mehere Fachbereiche abdecken.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
@@ -31,7 +31,7 @@
       {
         "id": "HealthcareService.specialty",
         "path": "HealthcareService.specialty",
-        "comment": "Kodierung alle Fachbereiche unter die die Behandlungseinheit fällt.",
+        "comment": "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
@@ -31,6 +31,7 @@
       {
         "id": "HealthcareService.specialty",
         "path": "HealthcareService.specialty",
+        "comment": "Kodierung alle Fachbereiche unter die die Behandlungseinheit fällt.",
         "min": 1,
         "mustSupport": true
       },

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
@@ -31,6 +31,12 @@
       {
         "id": "HealthcareService.specialty",
         "path": "HealthcareService.specialty",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "HealthcareService.specialty.coding",
+        "path": "HealthcareService.specialty.coding",
         "slicing": {
           "discriminator": [
             {
@@ -44,8 +50,8 @@
         "mustSupport": true
       },
       {
-        "id": "HealthcareService.specialty:Fachrichtung",
-        "path": "HealthcareService.specialty",
+        "id": "HealthcareService.specialty.coding:Fachrichtung",
+        "path": "HealthcareService.specialty.coding",
         "sliceName": "Fachrichtung",
         "comment": "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024).",
         "min": 1,
@@ -57,15 +63,15 @@
         }
       },
       {
-        "id": "HealthcareService.specialty:ErweiterterFachabteilungsschluessel",
-        "path": "HealthcareService.specialty",
+        "id": "HealthcareService.specialty.coding:ErweiterterFachabteilungsschluessel",
+        "path": "HealthcareService.specialty.coding",
         "sliceName": "ErweiterterFachabteilungsschluessel",
         "comment": "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern.",
         "min": 0,
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel-erweitert"
+          "valueSet": "http://fhir.de/ValueSet/dkgev/Fachabteilungsschluessel-erweitert"
         }
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
@@ -121,6 +121,7 @@
       {
         "id": "Appointment.specialty",
         "path": "Appointment.specialty",
+        "comment": "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders in dem ein Termin gebucht wird ermittelt werden.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
@@ -121,7 +121,7 @@
       {
         "id": "Appointment.specialty",
         "path": "Appointment.specialty",
-        "comment": "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders in dem ein Termin gebucht wird ermittelt werden.",
+        "comment": "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden.",
         "mustSupport": true
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
@@ -121,6 +121,11 @@
       {
         "id": "Appointment.specialty",
         "path": "Appointment.specialty",
+        "mustSupport": true
+      },
+      {
+        "id": "Appointment.specialty.coding",
+        "path": "Appointment.specialty.coding",
         "slicing": {
           "discriminator": [
             {
@@ -134,8 +139,8 @@
         "mustSupport": true
       },
       {
-        "id": "Appointment.specialty:Fachrichtung",
-        "path": "Appointment.specialty",
+        "id": "Appointment.specialty.coding:Fachrichtung",
+        "path": "Appointment.specialty.coding",
         "sliceName": "Fachrichtung",
         "comment": "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024).",
         "min": 1,
@@ -147,15 +152,15 @@
         }
       },
       {
-        "id": "Appointment.specialty:ErweiterterFachabteilungsschluessel",
-        "path": "Appointment.specialty",
+        "id": "Appointment.specialty.coding:ErweiterterFachabteilungsschluessel",
+        "path": "Appointment.specialty.coding",
         "sliceName": "ErweiterterFachabteilungsschluessel",
         "comment": "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern.",
         "min": 0,
         "max": "1",
         "binding": {
           "strength": "required",
-          "valueSet": "http://fhir.de/CodeSystem/dkgev/Fachabteilungsschluessel-erweitert"
+          "valueSet": "http://fhir.de/ValueSet/dkgev/Fachabteilungsschluessel-erweitert"
         }
       },
       {

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
@@ -121,7 +121,7 @@
       {
         "id": "Appointment.specialty",
         "path": "Appointment.specialty",
-        "comment": "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden.",
+        "comment": "Optionale Angabe aller Fachbereiche aus denen ein oder mehrere Akteure für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden.",
         "mustSupport": true
       },
       {

--- a/Resources/input/fsh/ISiKKalender.fsh
+++ b/Resources/input/fsh/ISiKKalender.fsh
@@ -5,15 +5,16 @@ Id: ISiKKalender
 * active 1..1 MS
 * serviceType 1..* MS
 * specialty 1..* MS
+* specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
-* specialty contains 
+* specialty.coding contains 
   Fachrichtung 1..1 MS and
   ErweiterterFachabteilungsschluessel 0..1
-* specialty[Fachrichtung] from $IHEpracticeSettingVS (required)
+* specialty.coding[Fachrichtung] from $IHEpracticeSettingVS (required)
   * ^comment = "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024)."
-* specialty[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertCS (required)
+* specialty.coding[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertVS (required)
   * ^comment = "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern."  
 * actor 1..* MS  
   * identifier 0..1 MS

--- a/Resources/input/fsh/ISiKKalender.fsh
+++ b/Resources/input/fsh/ISiKKalender.fsh
@@ -5,7 +5,7 @@ Id: ISiKKalender
 * active 1..1 MS
 * serviceType 1..* MS
 * specialty 1..* MS
-  * ^comment = "Ein Kalendar kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplannung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird."
+  * ^comment = "Ein Kalender kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplanung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird."
 * specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKKalender.fsh
+++ b/Resources/input/fsh/ISiKKalender.fsh
@@ -5,6 +5,7 @@ Id: ISiKKalender
 * active 1..1 MS
 * serviceType 1..* MS
 * specialty 1..* MS
+  * ^comment = "Ein Kalendar kann für einen Akteur gepflegt werden. Dieser Akteur kann in einer oder mehreren Fachrichtungen agieren. Für die Ressourcenplannung (z.B. welche Akteure sind für einen Termin verfügbar) sollte auch auf die Speciality des Akteurs zurückgegriffen werden für den Fall, dass ein Kalender pro Fachbereich gepflegt wird."
 * specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
@@ -16,7 +17,8 @@ Id: ISiKKalender
   * ^comment = "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024)."
 * specialty.coding[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertVS (required)
   * ^comment = "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern."  
-* actor 1..* MS  
+* actor 1..* MS
+  * ^comment = "Ein dezidierter Kalender ist für jeden Akteur zu pflegen."  
   * identifier 0..1 MS
   * display 1..1 MS
   * ^slicing.discriminator.type = #type

--- a/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
+++ b/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
@@ -5,6 +5,7 @@ Id: ISiKMedizinischeBehandlungseinheit
 * active 1..1 MS
 * type 1.. MS
 * specialty 1.. MS
+  * ^comment = "Kodierung alle Fachbereiche unter die die Behandlungseinheit fällt."
 * specialty.coding 1.. MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
+++ b/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
@@ -5,15 +5,16 @@ Id: ISiKMedizinischeBehandlungseinheit
 * active 1..1 MS
 * type 1.. MS
 * specialty 1.. MS
+* specialty.coding 1.. MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
-* specialty contains 
+* specialty.coding contains 
   Fachrichtung 1..1 MS and
   ErweiterterFachabteilungsschluessel 0..1
-* specialty[Fachrichtung] from $IHEpracticeSettingVS (required)
+* specialty.coding[Fachrichtung] from $IHEpracticeSettingVS (required)
   * ^comment = "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024)."
-* specialty[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertCS (required)
+* specialty.coding[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertVS (required)
   * ^comment = "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern."  
 * name 1.. MS
 
@@ -22,5 +23,5 @@ InstanceOf: ISiKMedizinischeBehandlungseinheit
 Usage: #example
 * active = true
 * type = http://terminology.hl7.org/CodeSystem/service-type#124
-* specialty[Fachrichtung] = $IHEAerztlicheFachrichtungen#ALLG
+* specialty.coding[Fachrichtung] = $IHEAerztlicheFachrichtungen#ALLG
 * name = "Allgemeine Beratungsstelle der Fachabteilung 0100"

--- a/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
+++ b/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
@@ -5,7 +5,7 @@ Id: ISiKMedizinischeBehandlungseinheit
 * active 1..1 MS
 * type 1.. MS
 * specialty 1.. MS
-  * ^comment = "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt."
+  * ^comment = "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt. Eine Behandlungseinheit kann multiprofessionell sein und mehere Fachbereiche abdecken."
 * specialty.coding 1.. MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
+++ b/Resources/input/fsh/ISiKMedizinischeBehandlungseinheit.fsh
@@ -5,7 +5,7 @@ Id: ISiKMedizinischeBehandlungseinheit
 * active 1..1 MS
 * type 1.. MS
 * specialty 1.. MS
-  * ^comment = "Kodierung alle Fachbereiche unter die die Behandlungseinheit fällt."
+  * ^comment = "Kodierung aller Fachbereiche unter die die Behandlungseinheit fällt."
 * specialty.coding 1.. MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKTermin.fsh
+++ b/Resources/input/fsh/ISiKTermin.fsh
@@ -60,7 +60,7 @@ Es gilt weiterhin der Hinweis der FHIR Kernspezifikation:
 * participant[AkteurMedizinischeBehandlungseinheit].actor MS
 * participant[AkteurMedizinischeBehandlungseinheit].actor.reference 1..1 MS
 * specialty 0..* MS
-  * ^comment = "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders in dem ein Termin gebucht wird ermittelt werden."
+  * ^comment = "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden."
 * specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKTermin.fsh
+++ b/Resources/input/fsh/ISiKTermin.fsh
@@ -60,7 +60,7 @@ Es gilt weiterhin der Hinweis der FHIR Kernspezifikation:
 * participant[AkteurMedizinischeBehandlungseinheit].actor MS
 * participant[AkteurMedizinischeBehandlungseinheit].actor.reference 1..1 MS
 * specialty 0..* MS
-  * ^comment = "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden."
+  * ^comment = "Optionale Angabe aller Fachbereiche aus denen ein oder mehrere Akteure für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders, in dem ein Termin gebucht wird, ermittelt werden."
 * specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"

--- a/Resources/input/fsh/ISiKTermin.fsh
+++ b/Resources/input/fsh/ISiKTermin.fsh
@@ -60,15 +60,16 @@ Es gilt weiterhin der Hinweis der FHIR Kernspezifikation:
 * participant[AkteurMedizinischeBehandlungseinheit].actor MS
 * participant[AkteurMedizinischeBehandlungseinheit].actor.reference 1..1 MS
 * specialty 0..* MS
+* specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"
   * ^slicing.rules = #open
-* specialty contains 
+* specialty.coding contains 
   Fachrichtung 1..1 MS and
   ErweiterterFachabteilungsschluessel 0..1
-* specialty[Fachrichtung] from $IHEpracticeSettingVS (required)
+* specialty.coding[Fachrichtung] from $IHEpracticeSettingVS (required)
   * ^comment = "Die Wahl des hinterlegten ValueSets (http://ihe-d.de/ValueSets/IHEXDSpracticeSettingCode) wurde mit einem Mitglied der IHE Deutschland Arbeitsgruppe XDS ValueSets (https://www.ihe-d.de/projekte/xds-value-sets-fuer-deutschland/) sowie mit der KBV abgestimmt (Stand:13.6.2024)."
-* specialty[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertCS (required)
+* specialty.coding[ErweiterterFachabteilungsschluessel] from $FachabteilungsschluesselErweitertVS (required)
   * ^comment = "Dieses ValueSet KANN über ein Mapping (siehe Abschnitt https://wiki.hl7.de/index.php?title=IG:Value_Sets_f%C3%BCr_XDS#DocumentEntry.practiceSettingCode) mit dem ValueSet der Fachrichtung verknüpft werden und darüber ggf. die Integration von Systemen erleichtern."  
 * serviceType 1..* MS 
 * priority MS
@@ -124,8 +125,8 @@ Usage: #example
 * priority
   * extension[ISiKTerminPriorityExtension].valueCodeableConcept = http://snomed.info/sct#25876001
 * serviceType = http://terminology.hl7.org/CodeSystem/service-type#174
-* specialty[Fachrichtung] = $IHEAerztlicheFachrichtungen#INTM
-* specialty[ErweiterterFachabteilungsschluessel] = $FachabteilungsschluesselErweitertCS#3600
+* specialty.coding[Fachrichtung] = $IHEAerztlicheFachrichtungen#INTM
+* specialty.coding[ErweiterterFachabteilungsschluessel] = $FachabteilungsschluesselErweitertCS#3600
 * participant
   * actor.display = "Test Patient"
   * actor.reference = "Patient/example"

--- a/Resources/input/fsh/ISiKTermin.fsh
+++ b/Resources/input/fsh/ISiKTermin.fsh
@@ -60,6 +60,7 @@ Es gilt weiterhin der Hinweis der FHIR Kernspezifikation:
 * participant[AkteurMedizinischeBehandlungseinheit].actor MS
 * participant[AkteurMedizinischeBehandlungseinheit].actor.reference 1..1 MS
 * specialty 0..* MS
+  * ^comment = "Optionale Angabe aller Fachbereiche aus denen ein oder mehere Akteuere die für die Durchführung des Termins benötigt werden. KANN auch anhand des Kalenders in dem ein Termin gebucht wird ermittelt werden."
 * specialty.coding 1..* MS
   * ^slicing.discriminator.type = #pattern
   * ^slicing.discriminator.path = "$this"


### PR DESCRIPTION
Problem:
Das Slicing in Kombination mit der Vorgabe zu Kodierung der Fachrichtung in den Profilen zum Kalender, Termin und Behandlungseinheit ist im status quo zu stark eingeschränkt mit Kardinalität 1..1.

Lösung:

Verschiebung des Slicing auf .specialty.coding.

- [ ] Änderung als Technical Correction 

Kontext:
Fixes PTDATA-1103 und ANFISK-309