### PR TITLE
Harmonisierung patient/subject SearchParameter

### DIFF
--- a/ImplementationGuide/markdown/ReleaseNotes.md
+++ b/ImplementationGuide/markdown/ReleaseNotes.md
@@ -8,6 +8,8 @@ Version 4.0.2
 
 Datum: tbd.
 
+* `change` Die Verbindlichkeit des Suchaparameters `subject` in Communication wurde von SHALL auf MAY reduziert. 
+Statt dessen wird der neue verbindliche Suchparameter `patient` eingeführt. Die geschieht zur Harmonisierung der Suchparameter mit den anderen ISiK-Modulen. 
 * ´improve´ Falscher Satz über keine notwendige Verbindlichkeit entfernt und Formulierung verbessert https://github.com/gematik/spec-ISiK-Terminplanung/pull/248
 
 ---

--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminplanungServer.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminplanungServer.json
@@ -632,13 +632,25 @@
               "extension": [
                 {
                   "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-                  "valueCode": "SHALL"
+                  "valueCode": "MAY"
                 }
               ],
               "name": "subject",
               "definition": "http://hl7.org/fhir/SearchParameter/Communication-subject",
               "type": "reference",
               "documentation": "**Beispiel:**    \n        `GET [base]/Communication?subject=Patient/ISiKPatientExample`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#reference).  "
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+              "type": "reference",
+              "documentation": "**Beispiel:**    \n        `GET [base]/Communication?patient=Patient/ISiKPatientExample`    \n        **Anwendungshinweis:**   \n        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#reference).  "
             },
             {
               "extension": [

--- a/Resources/input/fsh/ISiKTerminplanungCapabilityStatement.fsh
+++ b/Resources/input/fsh/ISiKTerminplanungCapabilityStatement.fsh
@@ -271,7 +271,7 @@ Dieses CapabilityStatement repräsentiert die Anforderungen an ein Termin-Reposi
       * code = #search-type
     * insert CommonSearchParameters  
     * searchParam[+]
-      * insert Expectation (#SHALL) 
+      * insert Expectation (#MAY) 
       * name = "subject"
       * definition = "http://hl7.org/fhir/SearchParameter/Communication-subject"
       * type = #reference
@@ -280,6 +280,16 @@ Dieses CapabilityStatement repräsentiert die Anforderungen an ein Termin-Reposi
         `GET [base]/Communication?subject=Patient/ISiKPatientExample`    
         **Anwendungshinweis:**   
         Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#reference).  " 
+    * searchParam[+]
+      * insert Expectation (#SHALL) 
+      * name = "patient"
+      * definition = "http://hl7.org/fhir/SearchParameter/clinical-patient"
+      * type = #reference
+      * documentation = 
+        "**Beispiel:**    
+        `GET [base]/Communication?patient=Patient/ISiKPatientExample`    
+        **Anwendungshinweis:**   
+        Weitere Details siehe [FHIR-Kernspezifikation](https://hl7.org/fhir/R4/search.html#reference).  "    
     * searchParam[+]
       * insert Expectation (#SHALL) 
       * name = "recipient"


### PR DESCRIPTION
Harmonisierung der SearchParameter subject/patient in Hinblick auf [PTDATA-1317](https://service.gematik.de/browse/PTDATA-1317) und [PTDATA-1328](https://service.gematik.de/browse/PTDATA-1328)