### PR TITLE
Update link to main yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
     
 jobs:
   call-tool-update:
-    uses: gematik/spec-isik-basismodul/.github/workflows/main.yml@main-isik-stufe-4
+    uses: gematik/spec-isik-basismodul/.github/workflows/main.yml@main-stufe-5
     secrets:
       SIMPLIFIER_USERNAME: ${{ secrets.SIMPLIFIER_USERNAME }}
       SIMPLIFIER_PASSWORD: ${{ secrets.SIMPLIFIER_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Use Basis main Stufe 4 main.yml
+name: Use Basis main Stufe 5 main.yml
 
 # Controls when the action will run
 on:

--- a/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminplanungServer.json
+++ b/Resources/fsh-generated/resources/CapabilityStatement-ISiKCapabilityStatementTerminplanungServer.json
@@ -6,7 +6,7 @@
   "experimental": false,
   "publisher": "gematik GmbH",
   "version": "3.0.8",
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "implementationGuide": [
     "https://gematik.de/fhir/isik/v3/Terminplanung/ImplementationGuide|3.0.8"
   ],

--- a/Resources/fsh-generated/resources/OperationDefinition-ISiKAppointmentBookOperation.json
+++ b/Resources/fsh-generated/resources/OperationDefinition-ISiKAppointmentBookOperation.json
@@ -5,7 +5,7 @@
   "experimental": false,
   "publisher": "gematik GmbH",
   "version": "3.0.8",
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "name": "book",
   "url": "https://gematik.de/fhir/isik/v3/Terminplanung/OperationDefinition/AppointmentBook",
   "kind": "operation",

--- a/Resources/fsh-generated/resources/StructureDefinition-AppointmentReplaces.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-AppointmentReplaces.json
@@ -6,7 +6,7 @@
   "name": "AppointmentReplaces",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "complex-type",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKKalender.json
@@ -6,7 +6,7 @@
   "name": "ISiKKalender",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKMedizinischeBehandlungseinheit.json
@@ -6,7 +6,7 @@
   "name": "ISiKMedizinischeBehandlungseinheit",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKNachricht.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKNachricht.json
@@ -6,7 +6,7 @@
   "name": "ISiKNachricht",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKNachrichtExtension.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKNachrichtExtension.json
@@ -6,7 +6,7 @@
   "name": "ISiKNachrichtExtension",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "complex-type",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTermin.json
@@ -6,7 +6,7 @@
   "name": "ISiKTermin",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminKontaktMitGesundheitseinrichtung.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminKontaktMitGesundheitseinrichtung.json
@@ -6,7 +6,7 @@
   "name": "ISiKTerminKontaktMitGesundheitseinrichtung",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminPriorityExtension.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminPriorityExtension.json
@@ -6,7 +6,7 @@
   "name": "ISiKTerminPriorityExtension",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "complex-type",

--- a/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminblock.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ISiKTerminblock.json
@@ -6,7 +6,7 @@
   "name": "ISiKTerminblock",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "resource",

--- a/Resources/fsh-generated/resources/StructureDefinition-ScheduleName.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-ScheduleName.json
@@ -6,7 +6,7 @@
   "name": "ScheduleName",
   "status": "active",
   "experimental": false,
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "publisher": "gematik GmbH",
   "fhirVersion": "4.0.1",
   "kind": "complex-type",

--- a/Resources/fsh-generated/resources/ValueSet-ISiKTerminCancelationReason.json
+++ b/Resources/fsh-generated/resources/ValueSet-ISiKTerminCancelationReason.json
@@ -8,7 +8,7 @@
   "url": "https://gematik.de/fhir/isik/v3/Terminplanung/ValueSet/ISiKTerminCancelationReason",
   "experimental": false,
   "publisher": "gematik GmbH",
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "compose": {
     "include": [
       {

--- a/Resources/fsh-generated/resources/ValueSet-ISiKTerminPriority.json
+++ b/Resources/fsh-generated/resources/ValueSet-ISiKTerminPriority.json
@@ -8,7 +8,7 @@
   "url": "https://gematik.de/fhir/isik/v3/Terminplanung/ValueSet/ISiKTerminPriority",
   "experimental": false,
   "publisher": "gematik GmbH",
-  "date": "2025-07-03",
+  "date": "2025-07-04",
   "compose": {
     "include": [
       {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     ],
     "dependencies": {
         "de.gematik.isik-basismodul": "3.0.x"
-      }
+    },
+    "devDependencies": {
+    "bfarm.terminologien.icd10gm": "2024.0.0",
+    "bfarm.terminologien.ops": "2024.0.0"
+  } 
 }
 


### PR DESCRIPTION
Updated the link to the main.yml, so that it points no longer to stufe-4, which is not being further developed, but to stufe-5 - the newest official version